### PR TITLE
Webpack HMR compatibility: update editInPlace.js

### DIFF
--- a/Resources/public/js/editInPlace.js
+++ b/Resources/public/js/editInPlace.js
@@ -11,8 +11,10 @@
         // it is not possible to use HTMLElement directly
         class XTrans extends HTMLElement {}
 
-        customElements.define("x-trans", XTrans);
-
+        if (!customElements.get('x-trans')) {
+            customElements.define("x-trans", XTrans);
+        }
+            
         return;
     }
 


### PR DESCRIPTION
For HMR compatibility.  Fix the javascript error display in console and webpack error overlay : "Failed to execute 'define' on 'CustomElementRegistry': the name "x-trans" has already been used with this registry"